### PR TITLE
Use syn to parse the attribute tokens

### DIFF
--- a/compile_validate/src/lib.rs
+++ b/compile_validate/src/lib.rs
@@ -1,12 +1,17 @@
+// Re-export the procedural macro so that users don't need to have both this
+// crate and validate_macros in their Cargo.toml.
+#[allow(unused_imports)]
+#[macro_use]
+extern crate validate_macros;
+pub use validate_macros::*;
+
 #[macro_export]
 macro_rules! validate_json {
     ($path: expr) => {
-        #[macro_use] extern crate validate_macros;
         #[allow(dead_code)]
         mod dsjfkdsjfolp {
-            #![allow(dead_code)]
             #[derive(Validate)]
-            #[ValidatePath = $path]
+            #[path = $path]
             struct ValidatedJSON;
         }
     }

--- a/compile_validate/validate_macros/Cargo.toml
+++ b/compile_validate/validate_macros/Cargo.toml
@@ -8,7 +8,6 @@ quote = "*"
 serde = "*"
 serde_json = "*"
 syn = "*"
-proc-macro2 = "*"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
I enjoyed your stream! Here are some ideas based on how I might have written the same macro. Feel free to close if you want to immortalize your implementation.

- Attributes are allowed to be arbitrary unstructured Rust tokens so there is an extra step to parse them into a structured representation -- what `macro_rules!` calls a $meta or "meta item". Once structured, we don't need to explicitly iterate tokens or rearrange bytes of the string to access the string literal.

- Generally you want to format errors with "{}" when panicking in a proc macro because otherwise they get shown to the user in Debug form.

- Re-exporting validate_macros from compile_validate avoids the user having to write both of those crates in their Cargo.toml.

- Quasi-quoting simplifies the string to tokens to string to result to token stream dance.

- In my experience attribute names are typically lowercase.